### PR TITLE
suggest: pick the last package in the returned list instead of the first

### DIFF
--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -153,7 +153,7 @@ func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*toke
 	if len(pkgs) <= 0 { // ignore errors
 		return nil, token.NoPos, nil
 	}
-	pkg := pkgs[0]
+	pkg := pkgs[len(pkgs)-1]
 
 	return pkg.Fset, pos, pkg.Types
 }


### PR DESCRIPTION
This fixes the case where more than one package is returned (for
example, when the package contains tests): because pos is set inside
ParseFile, it will have a value that is valid only in the last visited
package.

This is probably not the correct fix, because the documentation for
ParseFile says it should be thread-safe, and the current version is not
:(