### PR TITLE
Add request cancellation

### DIFF
--- a/gocode.go
+++ b/gocode.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"syscall"
 )
 
 var (
@@ -54,6 +55,7 @@ func cliContext() (context.Context, func()) {
 	sigs := make(chan os.Signal)
 	signal.Notify(sigs, os.Interrupt)
 	signal.Notify(sigs, os.Kill)
+	signal.Notify(sigs, syscall.SIGTERM)
 	go func() {
 		<-sigs
 		cancel()

--- a/gocode.go
+++ b/gocode.go
@@ -53,6 +53,7 @@ func cliContext() (context.Context, func()) {
 
 	sigs := make(chan os.Signal)
 	signal.Notify(sigs, os.Interrupt)
+	signal.Notify(sigs, os.Kill)
 	go func() {
 		<-sigs
 		cancel()

--- a/gocode.go
+++ b/gocode.go
@@ -53,10 +53,11 @@ func main() {
 	flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	sigs := make(chan os.Signal)
 	signal.Notify(sigs, os.Interrupt, os.Kill, syscall.SIGTERM)
-	defer func() {
+	go func() {
 		<-sigs
 		cancel()
 	}()

--- a/gocode_test.go
+++ b/gocode_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 )
 
+// use `go build . && go test .` to run this
 func TestCancellation_Panic(t *testing.T) {
 	// checks that neither server nor client panic on cancellation
 
@@ -81,6 +83,7 @@ func runClients(t *testing.T, serverAddr string) {
 	// start bunch of clients
 	for i := 0; i < N; i++ {
 		offset := i * 5
+		stdout := buffer.prefixed(fmt.Sprintf("client %d |", i))
 		go func() {
 			defer wg.Done()
 
@@ -90,7 +93,7 @@ func runClients(t *testing.T, serverAddr string) {
 				"-in", testFile,
 				"autocomplete", testFile, strconv.Itoa(offset))
 
-			cmd.Stderr, cmd.Stdout = buffer.prefixed("client | "), buffer.prefixed("client | ")
+			cmd.Stderr, cmd.Stdout = stdout, stdout
 			_ = cmd.Run()
 		}()
 	}

--- a/gocode_test.go
+++ b/gocode_test.go
@@ -1,0 +1,134 @@
+package main_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestCancellation(t *testing.T) {
+	const testServerAddress = "127.0.0.1:38383"
+
+	var buffer buffer
+	defer func() {
+		if t.Failed() {
+			t.Log("\n" + string(buffer.text))
+		}
+	}()
+
+	gocode, err := exec.LookPath("gocode")
+	if err != nil {
+		t.Skip(err)
+	}
+	t.Log("running test with ", gocode)
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+
+	// start the server
+	cmd := exec.CommandContext(serverCtx, gocode, "-s", "-debug",
+		"-sock", "tcp",
+		"-addr", testServerAddress,
+	)
+	cmd.Stderr, cmd.Stdout = buffer.prefixed("server | "), buffer.prefixed("server | ")
+
+	// stop server after five seconds
+	go func() {
+		time.Sleep(5 * time.Second)
+		serverCancel()
+	}()
+
+	// start server
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	runClients(t, testServerAddress)
+
+	time.Sleep(time.Second)
+
+	// cancel server when any of the clients fails
+	serverCancel()
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func runClients(t *testing.T, serverAddr string) {
+	var buffer buffer
+	defer func() {
+		if t.Failed() {
+			t.Log("\n" + string(buffer.text))
+		}
+	}()
+
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	var clientGroup errgroup.Group
+
+	// start bunch of clients
+	for i := 0; i < 10; i++ {
+		offset := i * 10
+		clientGroup.Go(func() error {
+			cmd := exec.CommandContext(clientCtx, "gocode",
+				"-sock", "tcp",
+				"-addr", serverAddr,
+				"autocomplete", "gocode_test.go", strconv.Itoa(offset))
+			cmd.Stderr, cmd.Stdout = buffer.prefixed("client | "), buffer.prefixed("client | ")
+			err := cmd.Run()
+			if err != nil {
+				return fmt.Errorf("client offset=%d: %v", offset, err)
+			}
+			return nil
+		})
+	}
+
+	// wait for a bit
+	time.Sleep(150 * time.Millisecond)
+
+	// cancel all clients
+	clientCancel()
+
+	err := clientGroup.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type buffer struct {
+	mu   sync.Mutex
+	text []byte
+}
+
+func (b *buffer) Write(prefix string, data []byte) (int, error) {
+	b.mu.Lock()
+	b.text = append(b.text, []byte(prefix)...)
+	b.text = append(b.text, data...)
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		b.text = append(b.text, '\n')
+	}
+	b.mu.Unlock()
+	return len(data), nil
+}
+
+func (buffer *buffer) prefixed(prefix string) *writer {
+	return &writer{
+		prefix: prefix,
+		buffer: buffer,
+	}
+}
+
+type writer struct {
+	prefix string
+	buffer *buffer
+}
+
+func (w *writer) Write(data []byte) (int, error) {
+	return w.buffer.Write(w.prefix, data)
+}

--- a/gocode_test.go
+++ b/gocode_test.go
@@ -74,7 +74,7 @@ func runClients(t *testing.T, serverAddr string) {
 
 	// start bunch of clients
 	for i := 0; i < 10; i++ {
-		offset := i * 10
+		offset := i * 5
 		clientGroup.Go(func() error {
 			cmd := exec.CommandContext(clientCtx, "gocode",
 				"-sock", "tcp",
@@ -90,7 +90,7 @@ func runClients(t *testing.T, serverAddr string) {
 	}
 
 	// wait for a bit
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 
 	// cancel all clients
 	clientCancel()

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -144,10 +144,6 @@ func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*toke
 			filename: data,
 		},
 		ParseFile: func(fset *token.FileSet, parseFilename string, _ []byte) (*ast.File, error) {
-			if ctx.Err() == context.Canceled {
-				return nil, context.Canceled
-			}
-
 			var src interface{}
 			var filePos token.Pos
 			mode := parser.DeclarationErrors

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -2,6 +2,7 @@ package suggest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -17,6 +18,8 @@ import (
 )
 
 type Config struct {
+	RequestContext context.Context
+
 	Logf               func(fmt string, args ...interface{})
 	Context            *PackedContext
 	Builtin            bool
@@ -125,6 +128,8 @@ func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*toke
 	var posMu sync.Mutex // guards pos and fileAST in ParseFile
 
 	cfg := &packages.Config{
+		Context: c.RequestContext,
+
 		Mode:       packages.LoadSyntax,
 		Env:        c.Context.Env,
 		Dir:        c.Context.Dir,

--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/keegancsmith/rpc"
-
 	"github.com/stamblerre/gocode/internal/suggest"
 )
 
@@ -75,7 +74,6 @@ type AutoCompleteReply struct {
 }
 
 func (s *Server) AutoComplete(ctx context.Context, req *AutoCompleteRequest, res *AutoCompleteReply) error {
-	// ensure panics don't kill server
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Printf("panic: %s\n\n", err)
@@ -102,7 +100,7 @@ func (s *Server) AutoComplete(ctx context.Context, req *AutoCompleteRequest, res
 		var buf bytes.Buffer
 		log.Printf("Got autocompletion request for '%s'\n", req.Filename)
 		log.Printf("Cursor at: %d\n", req.Cursor)
-		if len(req.Data) > req.Cursor {
+		if req.Cursor <= len(req.Data) {
 			buf.WriteString("-------------------------------------------------------\n")
 			buf.Write(req.Data[:req.Cursor])
 			buf.WriteString("#")

--- a/server.go
+++ b/server.go
@@ -102,13 +102,16 @@ func (s *Server) AutoComplete(ctx context.Context, req *AutoCompleteRequest, res
 		var buf bytes.Buffer
 		log.Printf("Got autocompletion request for '%s'\n", req.Filename)
 		log.Printf("Cursor at: %d\n", req.Cursor)
-		buf.WriteString("-------------------------------------------------------\n")
-		buf.Write(req.Data[:req.Cursor])
-		buf.WriteString("#")
-		buf.Write(req.Data[req.Cursor:])
-		log.Print(buf.String())
-		log.Println("-------------------------------------------------------")
+		if len(req.Data) > req.Cursor {
+			buf.WriteString("-------------------------------------------------------\n")
+			buf.Write(req.Data[:req.Cursor])
+			buf.WriteString("#")
+			buf.Write(req.Data[req.Cursor:])
+			log.Print(buf.String())
+			log.Println("-------------------------------------------------------")
+		}
 	}
+
 	now := time.Now()
 	cfg := suggest.Config{
 		RequestContext:     ctx,

--- a/vendor/github.com/keegancsmith/rpc/.travis.yml
+++ b/vendor/github.com/keegancsmith/rpc/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+sudo: false
+go:
+  - 1.x

--- a/vendor/github.com/keegancsmith/rpc/LICENSE
+++ b/vendor/github.com/keegancsmith/rpc/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/keegancsmith/rpc/README.md
+++ b/vendor/github.com/keegancsmith/rpc/README.md
@@ -1,0 +1,42 @@
+# rpc  [![Build Status](https://travis-ci.org/keegancsmith/rpc.svg?branch=master)](https://travis-ci.org/keegancsmith/rpc)
+
+This is a fork of the stdlib [net/rpc](https://golang.org/pkg/net/rpc/) which
+is frozen. It adds support for `context.Context` on the client and server,
+including propagating cancellation.
+
+The API is exactly the same, except `Client.Call` takes a `context.Context`,
+and Server methods are expected to take a `context.Context` as the first
+argument. Additionally the wire protocol is unchanged, so is backwards
+compatible with `net/rpc` clients.
+
+`DialHTTPPathTimeout` function is also added. A future release of rpc may
+update all Dial functions to instead take a context.
+
+## Why use net/rpc
+
+There are many alternatives for RPC in Go, the most popular being
+[GRPC](https://grpc.io/). However, `net/rpc` has the following nice
+properties:
+
+- Nice API
+- No need for IDL
+- Good performance
+
+The nice API is subjective. However, the API is small, simple and composable.
+which makes it quite powerful. IDL tools are things like GRPC requiring protoc
+to generate go code from the protobuf files. `net/rpc` has no third party
+dependencies nor code generation step, simplify the use of it. A benchmark
+done on the [6 Sep
+2016](https://github.com/golang/go/issues/16844#issuecomment-245261755)
+indicated `net/rpc` was 4x faster than GRPC. This is an outdated benchmark,
+but is an indication at the surprisingly good performance `net/rpc` provides.
+
+For more discussion on the pros and cons of `net/rpc` see the issue [proposal:
+freeze net/rpc](https://github.com/golang/go/issues/16844).
+
+## Details
+
+Last forked from commit [08ab820](https://github.com/golang/go/commit/08ab820)
+on 25 September 2018.
+
+Cancellation implemented via the rpc call `_goRPC_.Cancel`.

--- a/vendor/github.com/keegancsmith/rpc/client.go
+++ b/vendor/github.com/keegancsmith/rpc/client.go
@@ -1,0 +1,367 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rpc
+
+import (
+	"bufio"
+	"context"
+	"encoding/gob"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/keegancsmith/rpc/internal/svc"
+)
+
+// ServerError represents an error that has been returned from
+// the remote side of the RPC connection.
+type ServerError string
+
+func (e ServerError) Error() string {
+	return string(e)
+}
+
+var ErrShutdown = errors.New("connection is shut down")
+
+// Call represents an active RPC.
+type Call struct {
+	ServiceMethod string      // The name of the service and method to call.
+	Args          interface{} // The argument to the function (*struct).
+	Reply         interface{} // The reply from the function (*struct).
+	Error         error       // After completion, the error status.
+	Done          chan *Call  // Strobes when call is complete.
+	seq           uint64      // Sequence num used to send. Non-zero when sent.
+}
+
+// Client represents an RPC Client.
+// There may be multiple outstanding Calls associated
+// with a single Client, and a Client may be used by
+// multiple goroutines simultaneously.
+type Client struct {
+	codec ClientCodec
+
+	reqMutex sync.Mutex // protects following
+	request  Request
+
+	mutex    sync.Mutex // protects following
+	seq      uint64
+	pending  map[uint64]*Call
+	closing  bool // user has called Close
+	shutdown bool // server has told us to stop
+}
+
+// A ClientCodec implements writing of RPC requests and
+// reading of RPC responses for the client side of an RPC session.
+// The client calls WriteRequest to write a request to the connection
+// and calls ReadResponseHeader and ReadResponseBody in pairs
+// to read responses. The client calls Close when finished with the
+// connection. ReadResponseBody may be called with a nil
+// argument to force the body of the response to be read and then
+// discarded.
+// See NewClient's comment for information about concurrent access.
+type ClientCodec interface {
+	WriteRequest(*Request, interface{}) error
+	ReadResponseHeader(*Response) error
+	ReadResponseBody(interface{}) error
+
+	Close() error
+}
+
+func (client *Client) send(call *Call) {
+	client.reqMutex.Lock()
+	defer client.reqMutex.Unlock()
+
+	// Register this call.
+	client.mutex.Lock()
+	if client.shutdown || client.closing {
+		client.mutex.Unlock()
+		call.Error = ErrShutdown
+		call.done()
+		return
+	}
+	if call.seq != 0 {
+		// It has already been canceled, don't bother sending
+		call.Error = context.Canceled
+		client.mutex.Unlock()
+		call.done()
+		return
+	}
+	client.seq++
+	seq := client.seq
+	call.seq = seq
+	client.pending[seq] = call
+	client.mutex.Unlock()
+
+	// Encode and send the request.
+	client.request.Seq = seq
+	client.request.ServiceMethod = call.ServiceMethod
+	err := client.codec.WriteRequest(&client.request, call.Args)
+	if err != nil {
+		client.mutex.Lock()
+		call = client.pending[seq]
+		delete(client.pending, seq)
+		client.mutex.Unlock()
+		if call != nil {
+			call.Error = err
+			call.done()
+		}
+	}
+}
+
+func (client *Client) input() {
+	var err error
+	var response Response
+	for err == nil {
+		response = Response{}
+		err = client.codec.ReadResponseHeader(&response)
+		if err != nil {
+			break
+		}
+		seq := response.Seq
+		client.mutex.Lock()
+		call := client.pending[seq]
+		delete(client.pending, seq)
+		client.mutex.Unlock()
+
+		switch {
+		case call == nil:
+			// We've got no pending call. That usually means that
+			// WriteRequest partially failed, and call was already
+			// removed; response is a server telling us about an
+			// error reading request body. We should still attempt
+			// to read error body, but there's no one to give it to.
+			err = client.codec.ReadResponseBody(nil)
+			if err != nil {
+				err = errors.New("reading error body: " + err.Error())
+			}
+		case response.Error != "":
+			// We've got an error response. Give this to the request;
+			// any subsequent requests will get the ReadResponseBody
+			// error if there is one.
+			call.Error = ServerError(response.Error)
+			err = client.codec.ReadResponseBody(nil)
+			if err != nil {
+				err = errors.New("reading error body: " + err.Error())
+			}
+			call.done()
+		default:
+			err = client.codec.ReadResponseBody(call.Reply)
+			if err != nil {
+				call.Error = errors.New("reading body " + err.Error())
+			}
+			call.done()
+		}
+	}
+	// Terminate pending calls.
+	client.reqMutex.Lock()
+	client.mutex.Lock()
+	client.shutdown = true
+	closing := client.closing
+	if err == io.EOF {
+		if closing {
+			err = ErrShutdown
+		} else {
+			err = io.ErrUnexpectedEOF
+		}
+	}
+	for _, call := range client.pending {
+		call.Error = err
+		call.done()
+	}
+	client.mutex.Unlock()
+	client.reqMutex.Unlock()
+	if debugLog && err != io.EOF && !closing {
+		log.Println("rpc: client protocol error:", err)
+	}
+}
+
+func (call *Call) done() {
+	select {
+	case call.Done <- call:
+		// ok
+	default:
+		// We don't want to block here. It is the caller's responsibility to make
+		// sure the channel has enough buffer space. See comment in Go().
+		if debugLog {
+			log.Println("rpc: discarding Call reply due to insufficient Done chan capacity")
+		}
+	}
+}
+
+// NewClient returns a new Client to handle requests to the
+// set of services at the other end of the connection.
+// It adds a buffer to the write side of the connection so
+// the header and payload are sent as a unit.
+//
+// The read and write halves of the connection are serialized independently,
+// so no interlocking is required. However each half may be accessed
+// concurrently so the implementation of conn should protect against
+// concurrent reads or concurrent writes.
+func NewClient(conn io.ReadWriteCloser) *Client {
+	encBuf := bufio.NewWriter(conn)
+	client := &gobClientCodec{conn, gob.NewDecoder(conn), gob.NewEncoder(encBuf), encBuf}
+	return NewClientWithCodec(client)
+}
+
+// NewClientWithCodec is like NewClient but uses the specified
+// codec to encode requests and decode responses.
+func NewClientWithCodec(codec ClientCodec) *Client {
+	client := &Client{
+		codec:   codec,
+		pending: make(map[uint64]*Call),
+	}
+	go client.input()
+	return client
+}
+
+type gobClientCodec struct {
+	rwc    io.ReadWriteCloser
+	dec    *gob.Decoder
+	enc    *gob.Encoder
+	encBuf *bufio.Writer
+}
+
+func (c *gobClientCodec) WriteRequest(r *Request, body interface{}) (err error) {
+	if err = c.enc.Encode(r); err != nil {
+		return
+	}
+	if err = c.enc.Encode(body); err != nil {
+		return
+	}
+	return c.encBuf.Flush()
+}
+
+func (c *gobClientCodec) ReadResponseHeader(r *Response) error {
+	return c.dec.Decode(r)
+}
+
+func (c *gobClientCodec) ReadResponseBody(body interface{}) error {
+	return c.dec.Decode(body)
+}
+
+func (c *gobClientCodec) Close() error {
+	return c.rwc.Close()
+}
+
+// DialHTTP connects to an HTTP RPC server at the specified network address
+// listening on the default HTTP RPC path.
+func DialHTTP(network, address string) (*Client, error) {
+	return DialHTTPPath(network, address, DefaultRPCPath)
+}
+
+// DialHTTPPath connects to an HTTP RPC server
+// at the specified network address and path with a default timeout.
+func DialHTTPPath(network, address, path string) (*Client, error) {
+	return DialHTTPPathTimeout(network, address, path, 0)
+}
+
+// DialHTTPPathTimeout connects to an HTTP RPC server
+// at the specified network address and path with the specified timeout for Dialing.
+//
+// This is a function added by github.com/keegancsmith/rpc
+func DialHTTPPathTimeout(network, address, path string, timeout time.Duration) (*Client, error) {
+	var err error
+	conn, err := net.DialTimeout(network, address, timeout)
+	if err != nil {
+		return nil, err
+	}
+	io.WriteString(conn, "CONNECT "+path+" HTTP/1.0\n\n")
+
+	// Require successful HTTP response
+	// before switching to RPC protocol.
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: "CONNECT"})
+	if err == nil && resp.Status == connected {
+		return NewClient(conn), nil
+	}
+	if err == nil {
+		err = errors.New("unexpected HTTP response: " + resp.Status)
+	}
+	conn.Close()
+	return nil, &net.OpError{
+		Op:   "dial-http",
+		Net:  network + " " + address,
+		Addr: nil,
+		Err:  err,
+	}
+}
+
+// Dial connects to an RPC server at the specified network address.
+func Dial(network, address string) (*Client, error) {
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(conn), nil
+}
+
+// Close calls the underlying codec's Close method. If the connection is already
+// shutting down, ErrShutdown is returned.
+func (client *Client) Close() error {
+	client.mutex.Lock()
+	if client.closing {
+		client.mutex.Unlock()
+		return ErrShutdown
+	}
+	client.closing = true
+	client.mutex.Unlock()
+	return client.codec.Close()
+}
+
+// Go invokes the function asynchronously. It returns the Call structure representing
+// the invocation. The done channel will signal when the call is complete by returning
+// the same Call object. If done is nil, Go will allocate a new channel.
+// If non-nil, done must be buffered or Go will deliberately crash.
+func (client *Client) Go(serviceMethod string, args interface{}, reply interface{}, done chan *Call) *Call {
+	call := new(Call)
+	call.ServiceMethod = serviceMethod
+	call.Args = args
+	call.Reply = reply
+	if done == nil {
+		done = make(chan *Call, 10) // buffered.
+	} else {
+		// If caller passes done != nil, it must arrange that
+		// done has enough buffer for the number of simultaneous
+		// RPCs that will be using that channel. If the channel
+		// is totally unbuffered, it's best not to run at all.
+		if cap(done) == 0 {
+			log.Panic("rpc: done channel is unbuffered")
+		}
+	}
+	call.Done = done
+	client.send(call)
+	return call
+}
+
+// Call invokes the named function, waits for it to complete, and returns its error status.
+func (client *Client) Call(ctx context.Context, serviceMethod string, args interface{}, reply interface{}) error {
+	ch := make(chan *Call, 2) // 2 for this call and cancel
+	call := client.Go(serviceMethod, args, reply, ch)
+	select {
+	case <-call.Done:
+		return call.Error
+	case <-ctx.Done():
+		// Cancel the pending request on the client
+		client.mutex.Lock()
+		seq := call.seq
+		_, ok := client.pending[seq]
+		delete(client.pending, seq)
+		if seq == 0 {
+			// hasn't been sent yet, non-zero will prevent send
+			call.seq = 1
+		}
+		client.mutex.Unlock()
+
+		// Cancel running request on the server
+		if seq != 0 && ok {
+			client.Go("_goRPC_.Cancel", &svc.CancelArgs{Seq: seq}, nil, ch)
+		}
+
+		return ctx.Err()
+	}
+}

--- a/vendor/github.com/keegancsmith/rpc/debug.go
+++ b/vendor/github.com/keegancsmith/rpc/debug.go
@@ -1,0 +1,90 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rpc
+
+/*
+	Some HTML presented at http://machine:port/debug/rpc
+	Lists services, their methods, and some statistics, still rudimentary.
+*/
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+)
+
+const debugText = `<html>
+	<body>
+	<title>Services</title>
+	{{range .}}
+	<hr>
+	Service {{.Name}}
+	<hr>
+		<table>
+		<th align=center>Method</th><th align=center>Calls</th>
+		{{range .Method}}
+			<tr>
+			<td align=left font=fixed>{{.Name}}({{.Type.ArgType}}, {{.Type.ReplyType}}) error</td>
+			<td align=center>{{.Type.NumCalls}}</td>
+			</tr>
+		{{end}}
+		</table>
+	{{end}}
+	</body>
+	</html>`
+
+var debug = template.Must(template.New("RPC debug").Parse(debugText))
+
+// If set, print log statements for internal and I/O errors.
+var debugLog = false
+
+type debugMethod struct {
+	Type *methodType
+	Name string
+}
+
+type methodArray []debugMethod
+
+type debugService struct {
+	Service *service
+	Name    string
+	Method  methodArray
+}
+
+type serviceArray []debugService
+
+func (s serviceArray) Len() int           { return len(s) }
+func (s serviceArray) Less(i, j int) bool { return s[i].Name < s[j].Name }
+func (s serviceArray) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+func (m methodArray) Len() int           { return len(m) }
+func (m methodArray) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m methodArray) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+type debugHTTP struct {
+	*Server
+}
+
+// Runs at /debug/rpc
+func (server debugHTTP) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Build a sorted version of the data.
+	var services serviceArray
+	server.serviceMap.Range(func(snamei, svci interface{}) bool {
+		svc := svci.(*service)
+		ds := debugService{svc, snamei.(string), make(methodArray, 0, len(svc.method))}
+		for mname, method := range svc.method {
+			ds.Method = append(ds.Method, debugMethod{method, mname})
+		}
+		sort.Sort(ds.Method)
+		services = append(services, ds)
+		return true
+	})
+	sort.Sort(services)
+	err := debug.Execute(w, services)
+	if err != nil {
+		fmt.Fprintln(w, "rpc: error executing template:", err.Error())
+	}
+}

--- a/vendor/github.com/keegancsmith/rpc/internal/svc/svc.go
+++ b/vendor/github.com/keegancsmith/rpc/internal/svc/svc.go
@@ -1,0 +1,62 @@
+package svc
+
+import (
+	"context"
+	"sync"
+)
+
+// Pending manages a map of all pending requests to a rpc.Service for a
+// connection (an rpc.ServerCodec).
+type Pending struct {
+	mu sync.Mutex
+	m  map[uint64]context.CancelFunc // seq -> cancel
+}
+
+func NewPending() *Pending {
+	return &Pending{m: make(map[uint64]context.CancelFunc)}
+}
+
+func (s *Pending) Start(seq uint64) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	// we assume seq is not already in map. If not, the client is broken.
+	s.m[seq] = cancel
+	s.mu.Unlock()
+	return ctx
+}
+
+func (s *Pending) Cancel(seq uint64) {
+	s.mu.Lock()
+	cancel, ok := s.m[seq]
+	if ok {
+		delete(s.m, seq)
+	}
+	s.mu.Unlock()
+	if ok {
+		cancel()
+	}
+}
+
+type CancelArgs struct {
+	// Seq is the sequence number for the rpc.Call to cancel.
+	Seq uint64
+
+	// pending is the DS used by rpc.Server to track the ongoing calls for
+	// this connection. It should not be set by the client, the Service will
+	// set it.
+	pending *Pending
+}
+
+// SetPending sets the pending map for the server to use. Do not use on the
+// client.
+func (a *CancelArgs) SetPending(p *Pending) {
+	a.pending = p
+}
+
+// GoRPC is an internal service used by rpc.
+type GoRPC struct{}
+
+func (s *GoRPC) Cancel(ctx context.Context, args *CancelArgs, reply *bool) error {
+	args.pending.Cancel(args.Seq)
+	return nil
+}

--- a/vendor/github.com/keegancsmith/rpc/server.go
+++ b/vendor/github.com/keegancsmith/rpc/server.go
@@ -1,0 +1,764 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+	Package rpc is a fork of the stdlib net/rpc which is frozen. It adds
+	support for context.Context on the client and server, including
+	propogating cancellation. See the README at
+	https://github.com/keegancsmith/rpc for motivation why this exists.
+
+	The API is exactly the same, except Client.Call takes a context.Context,
+	and Server methods are expected to take a context.Context as the first
+	argument. The following is the original rpc godoc updated to include
+	context.Context. Additionally the wire protocol is unchanged, so is
+	backwards compatible with net/rpc clients.
+
+	Package rpc provides access to the exported methods of an object across a
+	network or other I/O connection.  A server registers an object, making it visible
+	as a service with the name of the type of the object.  After registration, exported
+	methods of the object will be accessible remotely.  A server may register multiple
+	objects (services) of different types but it is an error to register multiple
+	objects of the same type.
+
+	Only methods that satisfy these criteria will be made available for remote access;
+	other methods will be ignored:
+
+		- the method's type is exported.
+		- the method is exported.
+		- the method has three arguments.
+		- the method's first argument has type context.Context.
+		- the method's last two arguments are exported (or builtin) types.
+		- the method's third argument is a pointer.
+		- the method has return type error.
+
+	In effect, the method must look schematically like
+
+		func (t *T) MethodName(ctx context.Context, argType T1, replyType *T2) error
+
+	where T1 and T2 can be marshaled by encoding/gob.
+	These requirements apply even if a different codec is used.
+	(In the future, these requirements may soften for custom codecs.)
+
+	The method's second argument represents the arguments provided by the caller; the
+	third argument represents the result parameters to be returned to the caller.
+	The method's return value, if non-nil, is passed back as a string that the client
+	sees as if created by errors.New.  If an error is returned, the reply parameter
+	will not be sent back to the client.
+
+	The server may handle requests on a single connection by calling ServeConn.  More
+	typically it will create a network listener and call Accept or, for an HTTP
+	listener, HandleHTTP and http.Serve.
+
+	A client wishing to use the service establishes a connection and then invokes
+	NewClient on the connection.  The convenience function Dial (DialHTTP) performs
+	both steps for a raw network connection (an HTTP connection).  The resulting
+	Client object has two methods, Call and Go, that specify the service and method to
+	call, a pointer containing the arguments, and a pointer to receive the result
+	parameters.
+
+	The Call method waits for the remote call to complete while the Go method
+	launches the call asynchronously and signals completion using the Call
+	structure's Done channel.
+
+	Unless an explicit codec is set up, package encoding/gob is used to
+	transport the data.
+
+	Here is a simple example.  A server wishes to export an object of type Arith:
+
+		package server
+
+		import "errors"
+
+		type Args struct {
+			A, B int
+		}
+
+		type Quotient struct {
+			Quo, Rem int
+		}
+
+		type Arith int
+
+		func (t *Arith) Multiply(ctx context.Context, args *Args, reply *int) error {
+			*reply = args.A * args.B
+			return nil
+		}
+
+		func (t *Arith) Divide(ctx context.Context, args *Args, quo *Quotient) error {
+			if args.B == 0 {
+				return errors.New("divide by zero")
+			}
+			quo.Quo = args.A / args.B
+			quo.Rem = args.A % args.B
+			return nil
+		}
+
+	The server calls (for HTTP service):
+
+		arith := new(Arith)
+		rpc.Register(arith)
+		rpc.HandleHTTP()
+		l, e := net.Listen("tcp", ":1234")
+		if e != nil {
+			log.Fatal("listen error:", e)
+		}
+		go http.Serve(l, nil)
+
+	At this point, clients can see a service "Arith" with methods "Arith.Multiply" and
+	"Arith.Divide".  To invoke one, a client first dials the server:
+
+		client, err := rpc.DialHTTP("tcp", serverAddress + ":1234")
+		if err != nil {
+			log.Fatal("dialing:", err)
+		}
+
+	Then it can make a remote call:
+
+		// Synchronous call
+		args := &server.Args{7,8}
+		var reply int
+		err = client.Call(context.Background(), "Arith.Multiply", args, &reply)
+		if err != nil {
+			log.Fatal("arith error:", err)
+		}
+		fmt.Printf("Arith: %d*%d=%d", args.A, args.B, reply)
+
+	or
+
+		// Asynchronous call
+		quotient := new(Quotient)
+		divCall := client.Go("Arith.Divide", args, quotient, nil)
+		replyCall := <-divCall.Done	// will be equal to divCall
+		// check errors, print, etc.
+
+	A server implementation will often provide a simple, type-safe wrapper for the
+	client.
+
+	The net/rpc package is frozen and is not accepting new features.
+*/
+package rpc
+
+import (
+	"bufio"
+	"context"
+	"encoding/gob"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/keegancsmith/rpc/internal/svc"
+)
+
+const (
+	// Defaults used by HandleHTTP
+	DefaultRPCPath   = "/_goRPC_"
+	DefaultDebugPath = "/debug/rpc"
+)
+
+// Precompute the reflect type for error. Can't use error directly
+// because Typeof takes an empty interface value. This is annoying.
+var typeOfError = reflect.TypeOf((*error)(nil)).Elem()
+var typeOfCtx = reflect.TypeOf((*context.Context)(nil)).Elem()
+
+type methodType struct {
+	sync.Mutex // protects counters
+	method     reflect.Method
+	ArgType    reflect.Type
+	ReplyType  reflect.Type
+	numCalls   uint
+}
+
+type service struct {
+	name   string                 // name of service
+	rcvr   reflect.Value          // receiver of methods for the service
+	typ    reflect.Type           // type of the receiver
+	method map[string]*methodType // registered methods
+}
+
+// Request is a header written before every RPC call. It is used internally
+// but documented here as an aid to debugging, such as when analyzing
+// network traffic.
+type Request struct {
+	ServiceMethod string   // format: "Service.Method"
+	Seq           uint64   // sequence number chosen by client
+	next          *Request // for free list in Server
+}
+
+// Response is a header written before every RPC return. It is used internally
+// but documented here as an aid to debugging, such as when analyzing
+// network traffic.
+type Response struct {
+	ServiceMethod string    // echoes that of the Request
+	Seq           uint64    // echoes that of the request
+	Error         string    // error, if any.
+	next          *Response // for free list in Server
+}
+
+// Server represents an RPC Server.
+type Server struct {
+	serviceMap sync.Map   // map[string]*service
+	reqLock    sync.Mutex // protects freeReq
+	freeReq    *Request
+	respLock   sync.Mutex // protects freeResp
+	freeResp   *Response
+}
+
+// NewServer returns a new Server.
+func NewServer() *Server {
+	s := &Server{}
+	s.RegisterName("_goRPC_", &svc.GoRPC{})
+	return s
+}
+
+// DefaultServer is the default instance of *Server.
+var DefaultServer = NewServer()
+
+// Is this an exported - upper case - name?
+func isExported(name string) bool {
+	rune, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(rune)
+}
+
+// Is this type exported or a builtin?
+func isExportedOrBuiltinType(t reflect.Type) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	// PkgPath will be non-empty even for an exported type,
+	// so we need to check the type name as well.
+	return isExported(t.Name()) || t.PkgPath() == ""
+}
+
+// Register publishes in the server the set of methods of the
+// receiver value that satisfy the following conditions:
+//	- exported method of exported type
+//	- two arguments, both of exported type
+//	- the second argument is a pointer
+//	- one return value, of type error
+// It returns an error if the receiver is not an exported type or has
+// no suitable methods. It also logs the error using package log.
+// The client accesses each method using a string of the form "Type.Method",
+// where Type is the receiver's concrete type.
+func (server *Server) Register(rcvr interface{}) error {
+	return server.register(rcvr, "", false)
+}
+
+// RegisterName is like Register but uses the provided name for the type
+// instead of the receiver's concrete type.
+func (server *Server) RegisterName(name string, rcvr interface{}) error {
+	return server.register(rcvr, name, true)
+}
+
+func (server *Server) register(rcvr interface{}, name string, useName bool) error {
+	s := new(service)
+	s.typ = reflect.TypeOf(rcvr)
+	s.rcvr = reflect.ValueOf(rcvr)
+	sname := reflect.Indirect(s.rcvr).Type().Name()
+	if useName {
+		sname = name
+	}
+	if sname == "" {
+		s := "rpc.Register: no service name for type " + s.typ.String()
+		log.Print(s)
+		return errors.New(s)
+	}
+	if !isExported(sname) && !useName {
+		s := "rpc.Register: type " + sname + " is not exported"
+		log.Print(s)
+		return errors.New(s)
+	}
+	s.name = sname
+
+	// Install the methods
+	s.method = suitableMethods(s.typ, true)
+
+	if len(s.method) == 0 {
+		str := ""
+
+		// To help the user, see if a pointer receiver would work.
+		method := suitableMethods(reflect.PtrTo(s.typ), false)
+		if len(method) != 0 {
+			str = "rpc.Register: type " + sname + " has no exported methods of suitable type (hint: pass a pointer to value of that type)"
+		} else {
+			str = "rpc.Register: type " + sname + " has no exported methods of suitable type"
+		}
+		log.Print(str)
+		return errors.New(str)
+	}
+
+	if _, dup := server.serviceMap.LoadOrStore(sname, s); dup {
+		return errors.New("rpc: service already defined: " + sname)
+	}
+	return nil
+}
+
+// suitableMethods returns suitable Rpc methods of typ, it will report
+// error using log if reportErr is true.
+func suitableMethods(typ reflect.Type, reportErr bool) map[string]*methodType {
+	methods := make(map[string]*methodType)
+	for m := 0; m < typ.NumMethod(); m++ {
+		method := typ.Method(m)
+		mtype := method.Type
+		mname := method.Name
+		// Method must be exported.
+		if method.PkgPath != "" {
+			continue
+		}
+		// Method needs four ins: receiver, ctx, *args, *reply.
+		if mtype.NumIn() != 4 {
+			if reportErr {
+				log.Printf("rpc.Register: method %q has %d input parameters; needs exactly three\n", mname, mtype.NumIn())
+			}
+			continue
+		}
+		// First arg must be context.Context
+		if ctxType := mtype.In(1); ctxType != typeOfCtx {
+			if reportErr {
+				log.Printf("rpc.Register: return type of method %q is %q, must be error\n", mname, ctxType)
+			}
+			continue
+		}
+		// Second arg need not be a pointer.
+		argType := mtype.In(2)
+		if !isExportedOrBuiltinType(argType) {
+			if reportErr {
+				log.Printf("rpc.Register: argument type of method %q is not exported: %q\n", mname, argType)
+			}
+			continue
+		}
+		// Third arg must be a pointer.
+		replyType := mtype.In(3)
+		if replyType.Kind() != reflect.Ptr {
+			if reportErr {
+				log.Printf("rpc.Register: reply type of method %q is not a pointer: %q\n", mname, replyType)
+			}
+			continue
+		}
+		// Reply type must be exported.
+		if !isExportedOrBuiltinType(replyType) {
+			if reportErr {
+				log.Printf("rpc.Register: reply type of method %q is not exported: %q\n", mname, replyType)
+			}
+			continue
+		}
+		// Method needs one out.
+		if mtype.NumOut() != 1 {
+			if reportErr {
+				log.Printf("rpc.Register: method %q has %d output parameters; needs exactly one\n", mname, mtype.NumOut())
+			}
+			continue
+		}
+		// The return type of the method must be error.
+		if returnType := mtype.Out(0); returnType != typeOfError {
+			if reportErr {
+				log.Printf("rpc.Register: return type of method %q is %q, must be error\n", mname, returnType)
+			}
+			continue
+		}
+		methods[mname] = &methodType{method: method, ArgType: argType, ReplyType: replyType}
+	}
+	return methods
+}
+
+// A value sent as a placeholder for the server's response value when the server
+// receives an invalid request. It is never decoded by the client since the Response
+// contains an error when it is used.
+var invalidRequest = struct{}{}
+
+func (server *Server) sendResponse(sending *sync.Mutex, req *Request, reply interface{}, codec ServerCodec, errmsg string) {
+	resp := server.getResponse()
+	// Encode the response header
+	resp.ServiceMethod = req.ServiceMethod
+	if errmsg != "" {
+		resp.Error = errmsg
+		reply = invalidRequest
+	}
+	resp.Seq = req.Seq
+	sending.Lock()
+	err := codec.WriteResponse(resp, reply)
+	if debugLog && err != nil {
+		log.Println("rpc: writing response:", err)
+	}
+	sending.Unlock()
+	server.freeResponse(resp)
+}
+
+func (m *methodType) NumCalls() (n uint) {
+	m.Lock()
+	n = m.numCalls
+	m.Unlock()
+	return n
+}
+
+func (s *service) call(server *Server, sending *sync.Mutex, pending *svc.Pending, wg *sync.WaitGroup, mtype *methodType, req *Request, argv, replyv reflect.Value, codec ServerCodec) {
+	if wg != nil {
+		defer wg.Done()
+	}
+	// _goRPC_ service calls require internal state.
+	if s.name == "_goRPC_" {
+		switch v := argv.Interface().(type) {
+		case *svc.CancelArgs:
+			v.SetPending(pending)
+		}
+	}
+	mtype.Lock()
+	mtype.numCalls++
+	mtype.Unlock()
+	ctx := pending.Start(req.Seq)
+	defer pending.Cancel(req.Seq)
+	function := mtype.method.Func
+	// Invoke the method, providing a new value for the reply.
+	returnValues := function.Call([]reflect.Value{s.rcvr, reflect.ValueOf(ctx), argv, replyv})
+	// The return value for the method is an error.
+	errInter := returnValues[0].Interface()
+	errmsg := ""
+	if errInter != nil {
+		errmsg = errInter.(error).Error()
+	}
+	server.sendResponse(sending, req, replyv.Interface(), codec, errmsg)
+	server.freeRequest(req)
+}
+
+type gobServerCodec struct {
+	rwc    io.ReadWriteCloser
+	dec    *gob.Decoder
+	enc    *gob.Encoder
+	encBuf *bufio.Writer
+	closed bool
+}
+
+func (c *gobServerCodec) ReadRequestHeader(r *Request) error {
+	return c.dec.Decode(r)
+}
+
+func (c *gobServerCodec) ReadRequestBody(body interface{}) error {
+	return c.dec.Decode(body)
+}
+
+func (c *gobServerCodec) WriteResponse(r *Response, body interface{}) (err error) {
+	if err = c.enc.Encode(r); err != nil {
+		if c.encBuf.Flush() == nil {
+			// Gob couldn't encode the header. Should not happen, so if it does,
+			// shut down the connection to signal that the connection is broken.
+			log.Println("rpc: gob error encoding response:", err)
+			c.Close()
+		}
+		return
+	}
+	if err = c.enc.Encode(body); err != nil {
+		if c.encBuf.Flush() == nil {
+			// Was a gob problem encoding the body but the header has been written.
+			// Shut down the connection to signal that the connection is broken.
+			log.Println("rpc: gob error encoding body:", err)
+			c.Close()
+		}
+		return
+	}
+	return c.encBuf.Flush()
+}
+
+func (c *gobServerCodec) Close() error {
+	if c.closed {
+		// Only call c.rwc.Close once; otherwise the semantics are undefined.
+		return nil
+	}
+	c.closed = true
+	return c.rwc.Close()
+}
+
+// ServeConn runs the server on a single connection.
+// ServeConn blocks, serving the connection until the client hangs up.
+// The caller typically invokes ServeConn in a go statement.
+// ServeConn uses the gob wire format (see package gob) on the
+// connection. To use an alternate codec, use ServeCodec.
+// See NewClient's comment for information about concurrent access.
+func (server *Server) ServeConn(conn io.ReadWriteCloser) {
+	buf := bufio.NewWriter(conn)
+	srv := &gobServerCodec{
+		rwc:    conn,
+		dec:    gob.NewDecoder(conn),
+		enc:    gob.NewEncoder(buf),
+		encBuf: buf,
+	}
+	server.ServeCodec(srv)
+}
+
+// ServeCodec is like ServeConn but uses the specified codec to
+// decode requests and encode responses.
+func (server *Server) ServeCodec(codec ServerCodec) {
+	sending := new(sync.Mutex)
+	pending := svc.NewPending()
+	wg := new(sync.WaitGroup)
+	for {
+		service, mtype, req, argv, replyv, keepReading, err := server.readRequest(codec)
+		if err != nil {
+			if debugLog && err != io.EOF {
+				log.Println("rpc:", err)
+			}
+			if !keepReading {
+				break
+			}
+			// send a response if we actually managed to read a header.
+			if req != nil {
+				server.sendResponse(sending, req, invalidRequest, codec, err.Error())
+				server.freeRequest(req)
+			}
+			continue
+		}
+		wg.Add(1)
+		go service.call(server, sending, pending, wg, mtype, req, argv, replyv, codec)
+	}
+	// We've seen that there are no more requests.
+	// Wait for responses to be sent before closing codec.
+	wg.Wait()
+	codec.Close()
+}
+
+// ServeRequest is like ServeCodec but synchronously serves a single request.
+// It does not close the codec upon completion.
+func (server *Server) ServeRequest(codec ServerCodec) error {
+	sending := new(sync.Mutex)
+	pending := svc.NewPending()
+	service, mtype, req, argv, replyv, keepReading, err := server.readRequest(codec)
+	if err != nil {
+		if !keepReading {
+			return err
+		}
+		// send a response if we actually managed to read a header.
+		if req != nil {
+			server.sendResponse(sending, req, invalidRequest, codec, err.Error())
+			server.freeRequest(req)
+		}
+		return err
+	}
+	service.call(server, sending, pending, nil, mtype, req, argv, replyv, codec)
+	return nil
+}
+
+func (server *Server) getRequest() *Request {
+	server.reqLock.Lock()
+	req := server.freeReq
+	if req == nil {
+		req = new(Request)
+	} else {
+		server.freeReq = req.next
+		*req = Request{}
+	}
+	server.reqLock.Unlock()
+	return req
+}
+
+func (server *Server) freeRequest(req *Request) {
+	server.reqLock.Lock()
+	req.next = server.freeReq
+	server.freeReq = req
+	server.reqLock.Unlock()
+}
+
+func (server *Server) getResponse() *Response {
+	server.respLock.Lock()
+	resp := server.freeResp
+	if resp == nil {
+		resp = new(Response)
+	} else {
+		server.freeResp = resp.next
+		*resp = Response{}
+	}
+	server.respLock.Unlock()
+	return resp
+}
+
+func (server *Server) freeResponse(resp *Response) {
+	server.respLock.Lock()
+	resp.next = server.freeResp
+	server.freeResp = resp
+	server.respLock.Unlock()
+}
+
+func (server *Server) readRequest(codec ServerCodec) (service *service, mtype *methodType, req *Request, argv, replyv reflect.Value, keepReading bool, err error) {
+	service, mtype, req, keepReading, err = server.readRequestHeader(codec)
+	if err != nil {
+		if !keepReading {
+			return
+		}
+		// discard body
+		codec.ReadRequestBody(nil)
+		return
+	}
+
+	// Decode the argument value.
+	argIsValue := false // if true, need to indirect before calling.
+	if mtype.ArgType.Kind() == reflect.Ptr {
+		argv = reflect.New(mtype.ArgType.Elem())
+	} else {
+		argv = reflect.New(mtype.ArgType)
+		argIsValue = true
+	}
+	// argv guaranteed to be a pointer now.
+	if err = codec.ReadRequestBody(argv.Interface()); err != nil {
+		return
+	}
+	if argIsValue {
+		argv = argv.Elem()
+	}
+
+	replyv = reflect.New(mtype.ReplyType.Elem())
+
+	switch mtype.ReplyType.Elem().Kind() {
+	case reflect.Map:
+		replyv.Elem().Set(reflect.MakeMap(mtype.ReplyType.Elem()))
+	case reflect.Slice:
+		replyv.Elem().Set(reflect.MakeSlice(mtype.ReplyType.Elem(), 0, 0))
+	}
+	return
+}
+
+func (server *Server) readRequestHeader(codec ServerCodec) (svc *service, mtype *methodType, req *Request, keepReading bool, err error) {
+	// Grab the request header.
+	req = server.getRequest()
+	err = codec.ReadRequestHeader(req)
+	if err != nil {
+		req = nil
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return
+		}
+		err = errors.New("rpc: server cannot decode request: " + err.Error())
+		return
+	}
+
+	// We read the header successfully. If we see an error now,
+	// we can still recover and move on to the next request.
+	keepReading = true
+
+	dot := strings.LastIndex(req.ServiceMethod, ".")
+	if dot < 0 {
+		err = errors.New("rpc: service/method request ill-formed: " + req.ServiceMethod)
+		return
+	}
+	serviceName := req.ServiceMethod[:dot]
+	methodName := req.ServiceMethod[dot+1:]
+
+	// Look up the request.
+	svci, ok := server.serviceMap.Load(serviceName)
+	if !ok {
+		err = errors.New("rpc: can't find service " + req.ServiceMethod)
+		return
+	}
+	svc = svci.(*service)
+	mtype = svc.method[methodName]
+	if mtype == nil {
+		err = errors.New("rpc: can't find method " + req.ServiceMethod)
+	}
+	return
+}
+
+// Accept accepts connections on the listener and serves requests
+// for each incoming connection. Accept blocks until the listener
+// returns a non-nil error. The caller typically invokes Accept in a
+// go statement.
+func (server *Server) Accept(lis net.Listener) {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			log.Print("rpc.Serve: accept:", err.Error())
+			return
+		}
+		go server.ServeConn(conn)
+	}
+}
+
+// Register publishes the receiver's methods in the DefaultServer.
+func Register(rcvr interface{}) error { return DefaultServer.Register(rcvr) }
+
+// RegisterName is like Register but uses the provided name for the type
+// instead of the receiver's concrete type.
+func RegisterName(name string, rcvr interface{}) error {
+	return DefaultServer.RegisterName(name, rcvr)
+}
+
+// A ServerCodec implements reading of RPC requests and writing of
+// RPC responses for the server side of an RPC session.
+// The server calls ReadRequestHeader and ReadRequestBody in pairs
+// to read requests from the connection, and it calls WriteResponse to
+// write a response back. The server calls Close when finished with the
+// connection. ReadRequestBody may be called with a nil
+// argument to force the body of the request to be read and discarded.
+// See NewClient's comment for information about concurrent access.
+type ServerCodec interface {
+	ReadRequestHeader(*Request) error
+	ReadRequestBody(interface{}) error
+	WriteResponse(*Response, interface{}) error
+
+	// Close can be called multiple times and must be idempotent.
+	Close() error
+}
+
+// ServeConn runs the DefaultServer on a single connection.
+// ServeConn blocks, serving the connection until the client hangs up.
+// The caller typically invokes ServeConn in a go statement.
+// ServeConn uses the gob wire format (see package gob) on the
+// connection. To use an alternate codec, use ServeCodec.
+// See NewClient's comment for information about concurrent access.
+func ServeConn(conn io.ReadWriteCloser) {
+	DefaultServer.ServeConn(conn)
+}
+
+// ServeCodec is like ServeConn but uses the specified codec to
+// decode requests and encode responses.
+func ServeCodec(codec ServerCodec) {
+	DefaultServer.ServeCodec(codec)
+}
+
+// ServeRequest is like ServeCodec but synchronously serves a single request.
+// It does not close the codec upon completion.
+func ServeRequest(codec ServerCodec) error {
+	return DefaultServer.ServeRequest(codec)
+}
+
+// Accept accepts connections on the listener and serves requests
+// to DefaultServer for each incoming connection.
+// Accept blocks; the caller typically invokes it in a go statement.
+func Accept(lis net.Listener) { DefaultServer.Accept(lis) }
+
+// Can connect to RPC service using HTTP CONNECT to rpcPath.
+var connected = "200 Connected to Go RPC"
+
+// ServeHTTP implements an http.Handler that answers RPC requests.
+func (server *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "CONNECT" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		io.WriteString(w, "405 must CONNECT\n")
+		return
+	}
+	conn, _, err := w.(http.Hijacker).Hijack()
+	if err != nil {
+		log.Print("rpc hijacking ", req.RemoteAddr, ": ", err.Error())
+		return
+	}
+	io.WriteString(conn, "HTTP/1.0 "+connected+"\n\n")
+	server.ServeConn(conn)
+}
+
+// HandleHTTP registers an HTTP handler for RPC messages on rpcPath,
+// and a debugging handler on debugPath.
+// It is still necessary to invoke http.Serve(), typically in a go statement.
+func (server *Server) HandleHTTP(rpcPath, debugPath string) {
+	http.Handle(rpcPath, server)
+	http.Handle(debugPath, debugHTTP{server})
+}
+
+// HandleHTTP registers an HTTP handler for RPC messages to DefaultServer
+// on DefaultRPCPath and a debugging handler on DefaultDebugPath.
+// It is still necessary to invoke http.Serve(), typically in a go statement.
+func HandleHTTP() {
+	DefaultServer.HandleHTTP(DefaultRPCPath, DefaultDebugPath)
+}


### PR DESCRIPTION
This PR adds request cancellation, which is necessary to terminate any pending requests that happen in rapid succession.

1. Switch to using `github.com/keegancsmith/rpc`, which supports context cancellation.
2. Propagate `context.Context` to `packages.Load`, which is the bulk of suggest runtime.