### PR TITLE
Cancel when the main context is done, as well

### DIFF
--- a/server.go
+++ b/server.go
@@ -91,6 +91,7 @@ func (s *Server) AutoComplete(ctx context.Context, req *AutoCompleteRequest, res
 	go func() {
 		select {
 		case <-ctx.Done():
+			cancel()
 		case <-s.context.Done():
 			cancel()
 		}


### PR DESCRIPTION
Go's `case` statements do not fall through, so the `<-ctx.Done()` case actually doesn't cancel the request.  This commit ensures that the request is canceled if the main context is done, as well.